### PR TITLE
Query all inputs that include dam_root_img

### DIFF
--- a/src/content/after.js
+++ b/src/content/after.js
@@ -5,9 +5,9 @@
   const config = { attributes: true, childList: true, subtree: true };
 
   const callback = () => {
-    var folderFields = document.querySelectorAll("[name^=dam_fid_]");
+    var folderFields = document.querySelectorAll("[name*=dam_fid_]");
     folderFields.forEach(action);
-    var fields = document.querySelectorAll("[name^=dam_root_]");
+    var fields = document.querySelectorAll("[name*=dam_root_]");
     fields.forEach(action);
   };
 


### PR DESCRIPTION
With inline blocks the name of the input gets set to

InlineBlockName.dam_root_image_fieldname the current selector pattern only matches for fields that start with dam_root_image meaning inline block properties are ignored.